### PR TITLE
test: ignore `connect_to_syslog()` test

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -44,6 +44,7 @@ pub mod should {
     }
 
     #[test]
+    #[ignore]
     fn connect_to_syslog() {
         connect_syslog().unwrap();
     }


### PR DESCRIPTION
It isn't available during Fedora build.