### PR TITLE
spec: Specify license for ifcfg-devname binary

### DIFF
--- a/rust-ifcfg-devname.spec
+++ b/rust-ifcfg-devname.spec
@@ -24,7 +24,7 @@ Udev helper utility that provides network interface naming using ifcfg configura
 
 %package     -n %{crate}
 Summary:        %{summary}
-License:        GPLv3 or ASL 2.0 or MIT
+License:        GPLv3 and MIT
 
 %description -n %{crate} %{_description}
 


### PR DESCRIPTION
GPLv3 and MIT

Based on comment: https://bugzilla.redhat.com/show_bug.cgi?id=2051874#c15

Co-authored-by: Fabio Valentini <decathorpe@gmail.com>